### PR TITLE
Add ignored flags

### DIFF
--- a/ycm_extra_conf.jsondb.py
+++ b/ycm_extra_conf.jsondb.py
@@ -1,15 +1,15 @@
 import os
 
-# Set this to the absolute path to the folder (NOT the file!) containing the
-# compile_commands.json file to use that instead of 'flags'. See here for
-# more details: http://clang.llvm.org/docs/JSONCompilationDatabase.html
-compilation_database_folder = 'native-editor/build/osx_x64_debug/make'
-
 def DirectoryOfThisScript():
   return os.path.dirname( os.path.abspath( __file__ ) )
 
 import sys
 sys.path.insert(0, DirectoryOfThisScript())
+
+# Set this to the absolute path to the folder (NOT the file!) containing the
+# compile_commands.json file to use that instead of 'flags'. See here for
+# more details: http://clang.llvm.org/docs/JSONCompilationDatabase.html
+compilation_database_folder = DirectoryOfThisScript()
 
 import ycm_jsondb_core
 ycm_jsondb_core.Init(compilation_database_folder)

--- a/ycm_jsondb_config.py
+++ b/ycm_jsondb_config.py
@@ -1,29 +1,7 @@
 def GetAdditionalFlags():
   flags = []
+  return flags
 
-  # Xcode 5.1
-  #flags.append('-isystem')
-  #flags.append('/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1')
-  #flags.append('-isystem')
-  #flags.append('/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include')
-  #flags.append('-isystem')
-  #flags.append('/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/clang/5.1/include')
-
-  # Xcode 6
-  #flags.append('-isystem')
-  #flags.append('/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1')
-  #flags.append('-isystem')
-  #flags.append('/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include')
-  #flags.append('-isystem')
-  #flags.append('/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/clang/6.0/include')
-
-  # libc
-  flags.append('-isystem')
-  flags.append('/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.10.sdk/usr/include')
-
-  # llvm+clang from source
-  flags.append('-isystem')
-  flags.append('/Users/mg/local/clang_src/llvm_installed/bin/../include/c++/v1')
-  flags.append('-isystem')
-  flags.append('/Users/mg/local/clang_src/llvm_installed/bin/../lib/clang/3.6.0/include')
+def GetIgnoredFlags():
+  flags = ['-Werror']
   return flags

--- a/ycm_jsondb_core.py
+++ b/ycm_jsondb_core.py
@@ -215,6 +215,12 @@ def FlagsForFile(filename, directory):
     except ValueError:
       pass
 
+    try:
+      ignoredFlags = ycm_jsondb_config.GetIgnoredFlags()
+      final_flags = [flag for flag in final_flags if flag not in ignoredFlags]
+    except ValueError:
+      pass
+
   else:
     debugLog("database NOK")
     relative_to = directory


### PR DESCRIPTION
Some flags can be ignored by YCM.

Possible use case: I want YCM to draw warnings and errors with different colors even though I use -Werror for compiling.

Also removed system specific default paths. Instead, use the directory of the `.ycm_extra_conf.py` file as a default location of the compilation database and use no extra flags.
