### PR TITLE
Make installation easier

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,33 @@ the recommended setting if your filesystem supports symlinks.
 ./install.sh -l /path/to/your/project
 ```
 
-Edit the `ycm_jsondb_config.py` file in your project to set up additional
-compilation flags. Note that this file is always copied and not symlinked.
+To customize your project settings with a config file, copy
+`ycm_jsondb_config.py` instead of symlinking, then edit the config file.
 
 ```bash
-vi /path/to/your/project/ycm_jsondb_config.py
+./install.sh -Lyc /path/to/your/project
 ```
+
+To use a centralized config file stored somewhere else, use the `-s` switch to
+get some files from a different directory. Files that exist in the source
+directory are used from there, other files are used from the directory of the
+script (typically this git repo). In the following example,
+`ycm_jsondb_config.py` is used from the config directory, all others from the
+script directory.
+
+```bash
+cp ycm_jsondb_config.py /path/to/config/directory
+./install.sh -l -s /path/to/config/directory /path/to/your/project
+```
+
+By default, the compilation database is searched for in the directory where the
+`.ycm_extra_conf.py` resides (typically the project root directory). It can be
+changed from the config file if per-project config file is used. If a
+centralized config file is used, then it can also be changed from
+`.ycm_extra_conf.py`. In this case, copy that file instead of symlinking.
+
+```bash
+./install.sh -LcC -s /path/to/config/directory /path/to/your/project
+```
+
 

--- a/README.md
+++ b/README.md
@@ -1,35 +1,48 @@
 # ycm_extra_conf.jsondb
 VIM's YCM plugin's ycm_extra_conf distribution for json compilation databases.
 
-The goal of this repository is to provide a ycm python plugin, which automates the handling of compilation flags for your projects.
-Once you've setup your build system in your project to generate the compilation database, then you will never have to manually manage and maintain your compiler flags in your ycm_extra_conf file.
-This is extremely useful, if you are working with a huge number of compilcated C/C++ projects and you don't want to or can't maintain the compiler flags for each projects in your ycm_extra_conf files.
+The goal of this repository is to provide a ycm python plugin, which automates
+the handling of compilation flags for your projects.  Once you've setup your
+build system in your project to generate the compilation database, then you
+will never have to manually manage and maintain your compiler flags in your
+ycm_extra_conf file.  This is extremely useful, if you are working with a huge
+number of compilcated C/C++ projects and you don't want to or can't maintain
+the compiler flags for each projects in your ycm_extra_conf files.
 
-This is not a regular vim plugin. This project provides an alternative ycm_extra_conf file for the famous [YCM](https://github.com/Valloric/YouCompleteMe) vim plugin.
+This is not a regular vim plugin. This project provides an alternative
+ycm_extra_conf file for the famous
+[YCM](https://github.com/Valloric/YouCompleteMe) vim plugin.
 
-CMAKE can generate conveniently the [compilation database] (http://clang.llvm.org/docs/JSONCompilationDatabase.html).
-Of course it is possible to generate it with other build systems as well, since it can be just a plain text output of the build.
-Also you can use [BEAR](https://github.com/rizsotto/Bear) to generate the compilation database with any kind of build systems you have.
+CMAKE can generate conveniently the [compilation database]
+(http://clang.llvm.org/docs/JSONCompilationDatabase.html).  Of course it is
+possible to generate it with other build systems as well, since it can be just
+a plain text output of the build.  Also you can use
+[BEAR](https://github.com/rizsotto/Bear) to generate the compilation database
+with any kind of build systems you have.
 
-You might want to open files which are on the include paths of the compilation database. For that you need to setup vim's path. This can be automated too, see [CompileDbPath](https://github.com/martong/vim-compiledb-path) vim plugin.
+You might want to open files which are on the include paths of the compilation
+database. For that you need to setup vim's path. This can be automated too, see
+[CompileDbPath](https://github.com/martong/vim-compiledb-path) vim plugin.
 
 ##Setup
-### Set up the environment
-These settings are common to all of your vim projects.
+
+To install the scripts to your project, run `install.sh`.
+
+```bash
+./install.sh /path/to/your/project
 ```
-% export PYTHONPATH=$PYTHONPATH:/path/to/this/repo
+
+With the `-l` switch, symlinks are created instead of copying the files. It is
+the recommended setting if your filesystem supports symlinks.
+
+```bash
+./install.sh -l /path/to/your/project
 ```
-Set up the additional compiler flags which are specific to your system:
+
+Edit the `ycm_jsondb_config.py` file in your project to set up additional
+compilation flags. Note that this file is always copied and not symlinked.
+
+```bash
+vi /path/to/your/project/ycm_jsondb_config.py
 ```
-% vi /path/to/this/repo/ycm_jsondb_config.py
-```
-### Set up your project:
-These settings are project specific settings. One project is identified by it's containing directory.
-```
-% cp /path/to/this/repo/ycm_extra_conf.jsondb.py /path/to/yourproject/.ycm_extra_conf.py
-```
-Set up the location of the compile_commands.json file's directory:
-```
-% vi /path/to/yourproject/.ycm_extra_conf.py
-```
-Now, start vim from /path/to/yourproject/
+

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+print_usage() {
+    cat >&2 <<_END_
+Copy or symlink .ycm_extra_conf.py and related files to a target directory.
+
+Usage: $0 -h
+       $0 [-l] target
+
+Options:
+    -h        This help message.
+    -l        Symlink instead of copy.
+_END_
+}
+
+usage_error() {
+    print_usage
+    exit 2
+}
+
+# -------- Main body --------
+
+symlink=
+while getopts "hl" Option; do
+    case $Option in
+    h)
+        print_usage
+        exit
+        ;;
+    l)
+        symlink=yes
+        ;;
+    *)
+        usage_error
+        ;;
+    esac
+done
+
+shift $(($OPTIND - 1))
+
+target_directory="$1"
+
+if [ -z "$target_directory" ]; then
+    usage_error
+fi
+
+set -e
+script_dir=$(readlink -e "$(dirname "$(which "$0")")")
+target_directory=$(readlink -e "$target_directory")
+
+if [ -n "$symlink" ]; then
+    ln -s "$script_dir/ycm_jsondb_core.py" "$target_directory/ycm_jsondb_core.py"
+    ln -s "$script_dir/ycm_extra_conf.jsondb.py" "$target_directory/.ycm_extra_conf.py"
+else
+    cp "$script_dir/ycm_jsondb_core.py" "$target_directory/ycm_jsondb_core.py"
+    cp "$script_dir/ycm_extra_conf.jsondb.py" "$target_directory/.ycm_extra_conf.py"
+fi
+
+cp "$script_dir/ycm_jsondb_config.py" "$target_directory/ycm_jsondb_config.py"
+

--- a/ycm_extra_conf.jsondb.py
+++ b/ycm_extra_conf.jsondb.py
@@ -7,6 +7,13 @@ import sys
 sys.path.insert(0, DirectoryOfThisScript())
 
 import ycm_jsondb_config
+
+# By default, the compilation database is in the current folder (usually the
+# project root). It can be changed from the ycm_jsondb_config sctipt via the
+# GetCompilationDatabaseFolder function. If you are using a centralized config
+# file and have the compilation database in another place than the current
+# folder, then modify it here (but remember not to symlink this file when
+# installing).
 if "GetCompilationDatabaseFolder" in dir(ycm_jsondb_config):
   compilation_database_folder = ycm_jsondb_config.GetCompilationDatabaseFolder(
       DirectoryOfThisScript())

--- a/ycm_extra_conf.jsondb.py
+++ b/ycm_extra_conf.jsondb.py
@@ -6,10 +6,12 @@ def DirectoryOfThisScript():
 import sys
 sys.path.insert(0, DirectoryOfThisScript())
 
-# Set this to the absolute path to the folder (NOT the file!) containing the
-# compile_commands.json file to use that instead of 'flags'. See here for
-# more details: http://clang.llvm.org/docs/JSONCompilationDatabase.html
-compilation_database_folder = DirectoryOfThisScript()
+import ycm_jsondb_config
+if "GetCompilationDatabaseFolder" in dir(ycm_jsondb_config):
+  compilation_database_folder = ycm_jsondb_config.GetCompilationDatabaseFolder(
+      DirectoryOfThisScript())
+else:
+  compilation_database_folder = DirectoryOfThisScript()
 
 import ycm_jsondb_core
 ycm_jsondb_core.Init(compilation_database_folder)

--- a/ycm_jsondb_config.py.example
+++ b/ycm_jsondb_config.py.example
@@ -24,3 +24,9 @@ def GetAdditionalFlags():
 def GetIgnoredFlags():
   flags = ['-Werror']
   return flags
+
+# Return the absolute path to the folder (NOT the file!) containing the
+# compile_commands.json file. See here for more details:
+# http://clang.llvm.org/docs/JSONCompilationDatabase.html
+def GetCompilationDatabaseFolder(path):
+  return os.path.abspath(path + "/compilation_database_dir")


### PR DESCRIPTION
Added an install script that copies or symlinks the python files to a target directory. Also made some modifications so that it is never needed to modify .ycm_extra_conf.py, so it can be safely symlinked. The ycm_jsondb_config.py is always copied, and can be used to store everything that is project specific.
